### PR TITLE
Fixing typo on UserValidator message

### DIFF
--- a/Modelo.Service/Validators/UserValidator.cs
+++ b/Modelo.Service/Validators/UserValidator.cs
@@ -27,7 +27,7 @@ namespace Modelo.Service.Validators
 
             RuleFor(c => c.Name)
                 .NotEmpty().WithMessage("Is necessary to inform the name.")
-                .NotNull().WithMessage("Is necessary to inform the birth date.");
+                .NotNull().WithMessage("Is necessary to inform the name.");
         }
     }
 }


### PR DESCRIPTION
Error message for name should be "Is necessary to inform the name." instead of "Is necessary to inform the birth date.".